### PR TITLE
Reduced circular require paths for Application.php to improve psalm performance

### DIFF
--- a/classes/ClassLoader.php
+++ b/classes/ClassLoader.php
@@ -9,7 +9,7 @@ spl_autoload_register(function (string $class_name) {
     $classNameWithoutNamespace = array_pop($parts);
     $path =  "$classNameWithoutNamespace.php";
 
-    if(in_array($class_name, ['Application', 'CareerDev'])){
+    if(in_array($classNameWithoutNamespace, ['Application', 'CareerDev'])){
         $path = "../$path";
     }
 

--- a/classes/ExcludeList.php
+++ b/classes/ExcludeList.php
@@ -2,9 +2,7 @@
 
 namespace Vanderbilt\CareerDevLibrary;
 
-require_once(dirname(__FILE__)."/Download.php");
-require_once(dirname(__FILE__)."/Upload.php");
-require_once(dirname(__FILE__)."/../Application.php");
+require_once(__DIR__ . '/ClassLoader.php');
 
 class ExcludeList {
     public function __construct($type, $pid, $excludeList = [], $metadata = []) {

--- a/classes/FederalExPORTER.php
+++ b/classes/FederalExPORTER.php
@@ -2,8 +2,7 @@
 
 namespace Vanderbilt\CareerDevLibrary;
 
-require_once(dirname(__FILE__)."/../Application.php");
-require_once(dirname(__FILE__)."/REDCapManagement.php");
+require_once(__DIR__ . '/ClassLoader.php');
 
 define("DATA_DIRECTORY", "filterData");
 define("INTERMEDIATE_1_FED", "R01AndEquivsList_Fed.txt");

--- a/clean/remap.php
+++ b/clean/remap.php
@@ -5,9 +5,7 @@ use \Vanderbilt\CareerDevLibrary\Upload;
 use \Vanderbilt\CareerDevLibrary\Application;
 
 require_once(dirname(__FILE__)."/../charts/baseWeb.php");
-require_once(dirname(__FILE__)."/../Application.php");
-require_once(dirname(__FILE__)."/../classes/Download.php");
-require_once(dirname(__FILE__)."/../classes/Upload.php");
+require_once(__DIR__ . '/../classes/ClassLoader.php');
 
 $recordIds = Download::recordIds($token, $server);
 $tmpRecordId = 1000;

--- a/financial/activeBudget.php
+++ b/financial/activeBudget.php
@@ -7,11 +7,7 @@ use \Vanderbilt\CareerDevLibrary\REDCapManagement;
 use \Vanderbilt\CareerDevLibrary\Application;
 
 require_once(dirname(__FILE__)."/../charts/baseWeb.php");
-require_once(dirname(__FILE__)."/../Application.php");
-require_once(dirname(__FILE__)."/../classes/Grants.php");
-require_once(dirname(__FILE__)."/../classes/Grant.php");
-require_once(dirname(__FILE__)."/../classes/Download.php");
-require_once(dirname(__FILE__)."/../classes/REDCapManagement.php");
+require_once(__DIR__ . '/ClassLoader.php');
 require_once(APP_PATH_DOCROOT."Classes/System.php");
 
 \System::increaseMaxExecTime(3600);   // 1 hour

--- a/getAbstracts.php
+++ b/getAbstracts.php
@@ -6,11 +6,7 @@ use \Vanderbilt\CareerDevLibrary\REDCapManagement;
 use \Vanderbilt\CareerDevLibrary\Grant;
 
 require_once(dirname(__FILE__)."/small_base.php");
-require_once(dirname(__FILE__)."/Application.php");
-require_once(dirname(__FILE__)."/classes/Download.php");
-require_once(dirname(__FILE__)."/classes/REDCapManagement.php");
-require_once(dirname(__FILE__)."/classes/Grants.php");
-require_once(dirname(__FILE__)."/classes/Grant.php");
+require_once(__DIR__ . '/classes/ClassLoader.php');
 
 $records = Download::recordIds($token, $server);
 $metadata = Download::metadata($token, $server);

--- a/help/about.php
+++ b/help/about.php
@@ -5,8 +5,7 @@ use \Vanderbilt\CareerDevLibrary\Application;
 
 require_once(dirname(__FILE__)."/../small_base.php");
 require_once(dirname(__FILE__)."/../charts/baseWeb.php");
-require_once(dirname(__FILE__)."/../CareerDev.php");
-require_once(dirname(__FILE__)."/../Application.php");
+require_once(__DIR__ . '/../classes/ClassLoader.php');
 
 $version = CareerDev::getVersion();
 

--- a/import.php
+++ b/import.php
@@ -4,8 +4,7 @@ use \Vanderbilt\FlightTrackerExternalModule\CareerDev;
 use \Vanderbilt\CareerDevLibrary\Application;
 
 require_once(dirname(__FILE__)."/charts/baseWeb.php");
-require_once(dirname(__FILE__)."/CareerDev.php");
-require_once(dirname(__FILE__)."/Application.php");
+require_once(__DIR__ . '/classes/ClassLoader.php');
 
 if (isset($_GET['import']) && isset($_FILES['csv'])) {
     $tmpFilename = $_FILES['csv']['tmp_name'] ?? "";

--- a/log/index.php
+++ b/log/index.php
@@ -4,7 +4,7 @@ use \Vanderbilt\CareerDevLibrary\Application;
 use \Vanderbilt\CareerDevLibrary\DataTables;
 
 require_once(dirname(__FILE__)."/../charts/baseWeb.php");
-require_once(dirname(__FILE__)."/../Application.php");
+require_once(__DIR__ . '/../classes/ClassLoader.php');
 
 echo DataTables::makeIncludeHTML();
 

--- a/newFaculty.php
+++ b/newFaculty.php
@@ -3,7 +3,7 @@
 use \Vanderbilt\CareerDevLibrary\Application;
 
 require_once(dirname(__FILE__)."/small_base.php");
-require_once(dirname(__FILE__)."/Application.php");
+require_once(__DIR__ . '/ClassLoader.php');
 
 header('Content-Type: text/csv');
 header('Content-Disposition: attachment; filename="newScholars.csv"');


### PR DESCRIPTION
I was hoping to use Flight Tracker as a guinea pig to test a new feature.  However, for that to be useful I needed to cut down on the psalm scan time significantly.  I gave up after a couple of hours since it would take more time than I can justify to optimize things.  However, I wanted to document my progress in case either of us ever wanted to pick the torch back up.

I think this PR might be safe.  The `ClassLoader.php` change specifically is important for that class to find all other classes, though it seems this class might be somewhat redundant now that we have `Autoload.php`.  Feel free to just close this PR if it's not worth the effort to review & test.

Here is the command I used to find the most duplicated require calls:
```
mark@localhost:~/modules/flight_tracker_v9.9.9$ find -name '*.php'|xargs grep -h ^require|rev|cut -d'/' -f 1|rev|cut -d\' -f 1|cut -d\" -f1|sort |uniq -c|sort -nr
    192 Autoload.php
    149 small_base.php
     74 baseWeb.php
     58 ClassLoader.php
     33 base.php
     18 redcap_connect.php
     16 preliminary.php
     14 
     13 CareerDev.php
      9 Application.php
      8 css.php
      7 _header.php
      6 baseSelect.php
      6 System.php
      6 CareerDevHelp.php
      5 Download.php
```

All times mentioned below are from running our scan tool, but with the phpcs feature disabled (so, effectively only psalm taint analysis time).

 Code Changes | Psalm Time
----- | -----
None | 7 mins
This PR | 6 mins
Above plus replacing all Autoload.php references with ClassLoader.php | 5 mins
Above plus moving the contents of small_base.php and baseWeb.php to ClassLoader.php | 2 mins

My changes on the last couple of rows weren't nearly mature enough to include in this PR.  I do think it is absolutely possible to cut psalm scan time down to 2 minutes or less with a similar approach though.
